### PR TITLE
chore: change version number to support LiteXL 2.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: wangyoucao577/go-release-action@v1.23
+      - uses: wangyoucao577/go-release-action@v1.24
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}

--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,4 @@
--- mod-version:2 -- lite-xl 2.0
+-- mod-version:3
 local core = require 'core'
 local command = require 'core.command'
 local common = require 'core.common'


### PR DESCRIPTION
This makes `litepresence` work for LiteXL V2.1.